### PR TITLE
Add docling-serve as RAG component in Helm chart

### DIFF
--- a/deploy/helm/rag-ui/charts/docling-serve/.helmignore
+++ b/deploy/helm/rag-ui/charts/docling-serve/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/rag-ui/charts/docling-serve/Chart.yaml
+++ b/deploy/helm/rag-ui/charts/docling-serve/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: latest
+description: Helm chart for deploying Docling on OpenShift
+name: docling-chart
+type: application
+version: 0.1.0

--- a/deploy/helm/rag-ui/charts/docling-serve/templates/_helpers.tpl
+++ b/deploy/helm/rag-ui/charts/docling-serve/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "docling-chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "docling-chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "docling-chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "docling-chart.labels" -}}
+helm.sh/chart: {{ include "docling-chart.chart" . }}
+{{ include "docling-chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "docling-chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "docling-chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "docling-chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "docling-chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/rag-ui/charts/docling-serve/templates/deployment.yaml
+++ b/deploy/helm/rag-ui/charts/docling-serve/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-docling
+  labels:
+    app: {{ .Release.Name }}-docling
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-docling
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-docling
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - name: docling
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        ports:
+        - containerPort: {{ .Values.service.port }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}

--- a/deploy/helm/rag-ui/charts/docling-serve/templates/service.yaml
+++ b/deploy/helm/rag-ui/charts/docling-serve/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-docling
+spec:
+  selector:
+    app: {{ .Release.Name }}-docling
+  ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  type: {{ .Values.service.type }}

--- a/deploy/helm/rag-ui/charts/docling-serve/values.yaml
+++ b/deploy/helm/rag-ui/charts/docling-serve/values.yaml
@@ -1,0 +1,24 @@
+replicaCount: 1
+
+image:
+  repository: quay.io/docling-project/docling-serve
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 5001
+
+resources:
+  limits:
+    cpu: "1000m"
+    memory: "2Gi"
+  requests:
+    cpu: "500m"
+    memory: "1Gi"
+
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  allowPrivilegeEscalation: false


### PR DESCRIPTION
This PR adds docling-serve as a deployable RAG component within the Helm chart. It enables semantic search and document retrieval via embeddings, forming the retrieval layer of a RAG pipeline. The service is modular and can be integrated with other components like embedding servers (e.g., all-mpnet-base-v2) and inference backends (e.g., vLLM) to build end-to-end retrieval-augmented systems. I'm currently working on the embedding part of it. This is the first iteration.

Additions:

Helm templates for docling-serve deployment and service
Default values