### PR TITLE
Support llamastack on CRC/CPU

### DIFF
--- a/deploy/helm/deploy.sh
+++ b/deploy/helm/deploy.sh
@@ -22,9 +22,13 @@ oc annotate secret pgvector -n $NAMESPACE meta.helm.sh/release-name=rag meta.hel
 
 # DOMAIN=$(kubectl get Ingress.config.openshift.io/cluster -o jsonpath='{.spec.domain}')
 
-helm upgrade --install rag rag-ui -n $NAMESPACE \
---set-json llama-serve.tolerations='[{"key":"g6e-gpu","effect":"NoSchedule","operator":"Exists"}]' \
---set-json safety-model.tolerations='[{"key":"odh-notebook","effect":"NoSchedule","operator":"Exists"}]'  
+if [[ -n $DEPLOY_CRC_CPU ]]; then
+	helm upgrade --install rag rag-ui -n $NAMESPACE --values rag-ui/values-crc-cpu.yaml
+else
+	helm upgrade --install rag rag-ui -n $NAMESPACE \
+		--set-json llama-serve.tolerations='[{"key":"g6e-gpu","effect":"NoSchedule","operator":"Exists"}]' \
+		--set-json safety-model.tolerations='[{"key":"odh-notebook","effect":"NoSchedule","operator":"Exists"}]'
+fi
 
 echo "Listing pods..."
 kubectl get pods -n $NAMESPACE

--- a/deploy/helm/rag-ui/charts/llama-serve/templates/deployment.yaml
+++ b/deploy/helm/rag-ui/charts/llama-serve/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- toYaml .Values.args | nindent 12 }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
           ports:
@@ -46,8 +49,10 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/rag-ui/charts/llama-serve/values.yaml
+++ b/deploy/helm/rag-ui/charts/llama-serve/values.yaml
@@ -4,12 +4,6 @@
 
 replicaCount: 1
 
-image:
-  repository: vllm/vllm-openai
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
-
 imagePullSecrets: []
 nameOverride: "vllm"
 fullnameOverride: "vllm"
@@ -32,22 +26,10 @@ service:
   type: ClusterIP
   port: 8000
 
-resources:
-  limits:
-    nvidia.com/gpu: "1"
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+serviceAccount:
+  create: false
+
 args:
-  - --model
-  - meta-llama/Llama-3.2-3B-Instruct
   - --enable-auto-tool-choice
   - --chat-template
   - /app/tool_chat_template_llama3.2_json.jinja
@@ -57,9 +39,6 @@ args:
   - "8000"
   - '--max-model-len'
   - '8192'
-
-serviceAccount:
-  create: false
 
 env:
   - name: VLLM_PORT
@@ -91,10 +70,5 @@ volumeMounts:
 
 
 nodeSelector: {}
-
-tolerations:
-  - effect: NoSchedule
-    key: g6e-gpu
-    value: 'true'
 
 affinity: {}

--- a/deploy/helm/rag-ui/charts/llama-stack/files/config.yaml
+++ b/deploy/helm/rag-ui/charts/llama-stack/files/config.yaml
@@ -58,14 +58,26 @@ providers:
   eval:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
-    config: {}
+    config:
+      kvstore:
+        type: sqlite
+        namespace: null
+        db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/remote-vllm}/meta_reference_eval.db
   datasetio:
   - provider_id: huggingface
     provider_type: remote::huggingface
-    config: {}
+    config:
+      kvstore:
+        type: sqlite
+        namespace: null
+        db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/remote-vllm}/huggingface_datasetio.db
   - provider_id: localfs
     provider_type: inline::localfs
-    config: {}
+    config:
+      kvstore:
+        type: sqlite
+        namespace: null
+        db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/remote-vllm}/localfs_datasetio.db
   scoring:
   - provider_id: basic
     provider_type: inline::basic
@@ -81,9 +93,7 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      service_name: ${env.OTEL_SERVICE_NAME:llama-stack}
-      sinks: ${env.TELEMETRY_SINKS:console,otel,sqlite}
-      otel_endpoint: ${env.OTEL_ENDPOINT:}
+      sinks: ${env.TELEMETRY_SINKS:console,sqlite}
       sqlite_db_path: ${env.SQLITE_DB_PATH:~/.llama/distributions/remote-vllm/trace_store.db}
   tool_runtime:
   - provider_id: brave-search

--- a/deploy/helm/rag-ui/charts/llama-stack/templates/deployment.yaml
+++ b/deploy/helm/rag-ui/charts/llama-stack/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
             {{- toYaml .Values.args | nindent 12 }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/deploy/helm/rag-ui/charts/safety-model/templates/deployment.yaml
+++ b/deploy/helm/rag-ui/charts/safety-model/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- toYaml .Values.args | nindent 12 }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
           ports:
@@ -46,8 +49,10 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/rag-ui/charts/safety-model/values.yaml
+++ b/deploy/helm/rag-ui/charts/safety-model/values.yaml
@@ -4,12 +4,6 @@
 
 replicaCount: 1
 
-image:
-  repository: vllm/vllm-openai
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
-
 imagePullSecrets: []
 nameOverride: "safety"
 fullnameOverride: "safety"
@@ -37,12 +31,11 @@ service:
   port: 8000
 
 args:
-  - --model
-  - meta-llama/Llama-Guard-3-8B
   - --port
   - "8000"
   - '--max-model-len'
   - '8192'
+
 env:
   - name: VLLM_PORT
     value: "8000"
@@ -52,20 +45,6 @@ env:
         key: HF_TOKEN
         name: huggingface-secret
  
-resources:
-  limits:
-    nvidia.com/gpu: "1"
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
 autoscaling:
   enabled: false
 
@@ -97,10 +76,5 @@ volumeMounts:
 #   readOnly: true
 
 nodeSelector: {}
-
-tolerations:
-  - effect: NoSchedule
-    key: odh-notebook
-    value: 'true'
 
 affinity: {}

--- a/deploy/helm/rag-ui/values-crc-cpu.yaml
+++ b/deploy/helm/rag-ui/values-crc-cpu.yaml
@@ -1,23 +1,22 @@
-# Default values for llama-stack.
+# Default values for rag-ui.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
 
 image:
-  repository: llamastack/distribution-remote-vllm
+  repository: quay.io/yuvalturg/llamastack-dist-ui
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.1.9"
+  tag: 0.1.9
 
 imagePullSecrets: []
-nameOverride: "llamastack"
-fullnameOverride: "llamastack"
+nameOverride: ""
+fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
   create: false
-
 
 podAnnotations: {}
 podLabels: {}
@@ -35,49 +34,27 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 8321
+  port: 8501
 
-args:
-  - --config
-  - /app-config/config.yaml
 env:
-  - name: VLLM_MAX_TOKENS
-    value: "4096"
-  - name: VLLM_URL
-    value: http://vllm:8000/v1
-  - name: VLLM_API_TOKEN
-    value: fake
-  - name:  SAFETY_VLLM_URL
-    value: http://safety:8000/v1
-  - name: OTEL_ENDPOINT
-    value: http://otel-collector-collector.observability-hub.svc.cluster.local:4318/v1/traces
-  - name: POSTGRES_USER
-    valueFrom:
-      secretKeyRef:
-        key: username
-        name: pgvector
-  - name: POSTGRES_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        key: password
-        name: pgvector
-  - name: POSTGRES_HOST
-    valueFrom:
-      secretKeyRef:
-        key: host
-        name: pgvector
-  - name: POSTGRES_PORT
-    valueFrom:
-      secretKeyRef:
-        key: port
-        name: pgvector
-  - name: PGVECTOR_DBNAME
-    valueFrom:
-      secretKeyRef:
-        key: dbname
-        name: pgvector
+  - name: LLAMA_STACK_ENDPOINT
+    value: 'http://llamastack:8321'
 
-
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -91,34 +68,27 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
 
 autoscaling:
   enabled: false
 
 # Additional volumes on the output Deployment definition.
-volumes:
-  - configMap:
-      defaultMode: 420
-      name: run-config
-    name: run-config-volume
-  - emptyDir: {}
-    name: llama-temp
-  - emptyDir: {}
-    name: cache
-
+volumes: []
 # - name: foo
 #   secret:
 #     secretName: mysecret
 #     optional: false
 
 # Additional volumeMounts on the output Deployment definition.
-volumeMounts:
-  - mountPath: /app-config
-    name: run-config-volume
-  - mountPath: /.llama
-    name: llama-temp
-  - mountPath: /.cache
-    name: cache
+volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
@@ -128,3 +98,32 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+llama-stack:
+  extraEnv:
+    - name: INFERENCE_MODEL
+      value: meta-llama/Llama-3.2-1B-Instruct
+    - name:  SAFETY_MODEL
+      value: meta-llama/Llama-Guard-3-1B
+
+llama-serve:
+  extraArgs:
+    - --model
+    - meta-llama/Llama-3.2-1B-Instruct
+  tolerations: []
+  resources: null
+  image:
+    repository: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo
+    pullPolicy: IfNotPresent
+    tag: v0.8.1
+
+safety-model:
+  extraArgs:
+    - --model
+    - meta-llama/Llama-Guard-3-1B
+  tolerations: []
+  resources: null
+  image:
+    repository: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo
+    pullPolicy: IfNotPresent
+    tag: v0.8.1

--- a/deploy/helm/rag-ui/values.yaml
+++ b/deploy/helm/rag-ui/values.yaml
@@ -5,10 +5,10 @@
 replicaCount: 1
 
 image:
-  repository: quay.io/sauagarw/llama-stack-ui
+  repository: quay.io/yuvalturg/llamastack-dist-ui
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: 0.1.9
 
 imagePullSecrets: []
 nameOverride: ""
@@ -99,15 +99,41 @@ tolerations: []
 
 affinity: {}
 
+llama-stack:
+  extraEnv:
+    - name: INFERENCE_MODEL
+      value: meta-llama/Llama-3.2-8B-Instruct
+    - name:  SAFETY_MODEL
+      value: meta-llama/Llama-Guard-3-8B
+
 llama-serve:
+  extraArgs:
+    - --model
+    - meta-llama/Llama-3.2-8B-Instruct
   tolerations:
     - effect: NoSchedule
       key: g6e-gpu
       value: 'true'
+  resources:
+    limits:
+      nvidia.com/gpu: "1"
+  image:
+    repository: vllm/vllm-openai
+    pullPolicy: IfNotPresent
+    tag: latest
 
 safety-model:
+  extraArgs:
+    - --model
+    - meta-llama/Llama-Guard-3-8B
   tolerations:
     - effect: NoSchedule
       key: odh-notebook
       value: 'true'
-  
+  resources:
+    limits:
+      nvidia.com/gpu: "1"
+  image:
+    repository: vllm/vllm-openai
+    pullPolicy: IfNotPresent
+    tag: latest


### PR DESCRIPTION
- Bumped llamastack version to 0.1.9 to match the api version in ui
- Added a values-crc-cpu for crc deployment (smaller models)
- Using a newer ui code from llamastack with minor modifications