### PR TITLE
FIX LLM Model Name

### DIFF
--- a/deploy/helm/rag-ui/values.yaml
+++ b/deploy/helm/rag-ui/values.yaml
@@ -102,14 +102,14 @@ affinity: {}
 llama-stack:
   extraEnv:
     - name: INFERENCE_MODEL
-      value: meta-llama/Llama-3.2-8B-Instruct
+      value: meta-llama/Llama-3.2-3B-Instruct
     - name:  SAFETY_MODEL
       value: meta-llama/Llama-Guard-3-8B
 
 llama-serve:
   extraArgs:
     - --model
-    - meta-llama/Llama-3.2-8B-Instruct
+    - meta-llama/Llama-3.2-3B-Instruct
   tolerations:
     - effect: NoSchedule
       key: g6e-gpu


### PR DESCRIPTION
I got the error below after the last few merges:

```
ERROR 04-04 14:01:12 [config.py:100] If you are trying to access a private or gated repo, make sure you are authenticated.
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/huggingface_hub/utils/_http.py", line 409, in hf_raise_for_status
    response.raise_for_status()
  File "/usr/local/lib/python3.12/dist-packages/requests/models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://huggingface.co/api/models/meta-llama/Llama-3.2-8B-Instruct/tree/main?recursive=True&expand=False
```
 I checked huggingface's repo and indeed it's not Llama-3.2-8B but Llama-3.2-3B. Only the guard model has 8B.

I just changed the name. It's running correctly now.

```
INFO 04-04 14:17:53 [weight_utils.py:281] Time spent downloading weights for meta-llama/Llama-3.2-3B-Instruct: 24.214031 seconds
...
INFO 04-04 14:19:03 [api_server.py:1028] Starting vLLM API server on http://0.0.0.0:8000
INFO 04-04 14:19:03 [launcher.py:26] Available routes are:

```