### PR TITLE
Manage secrets as part of Helm chart

### DIFF
--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -67,19 +67,6 @@ namespace:
 	oc create namespace $(NAMESPACE) && oc label namespace $(NAMESPACE) modelmesh-enabled=false ||:
 	oc project $(NAMESPACE) ||:
 
-secrets:
-	@oc get secret -n $(NAMESPACE) minio 2>/dev/null || { \
-		echo "Creating minio secret"; \
-		oc create secret -n $(NAMESPACE) generic minio \
-			--from-literal=username=$(MINIO_USER) \
-			--from-literal=password=$(MINIO_PASSWORD) \
-			--from-literal=host=minio \
-			--from-literal=port=9000; \
-	}
-
-	@echo "Annotating secrets..."
-	oc annotate secret minio -n $(NAMESPACE) meta.helm.sh/release-name=rag meta.helm.sh/release-namespace=$(NAMESPACE)
-
 .PHONY: pg-vector
 pg-vector:
 
@@ -128,7 +115,7 @@ helm_llm_service_args = \
     $(if $(LLM_TOLERATION),--set-json models.$(LLM).inferenceService.tolerations='$(call TOLERATIONS_TEMPLATE,$(LLM_TOLERATION))',) \
     $(if $(SAFETY_TOLERATION),--set-json models.$(SAFETY).inferenceService.tolerations='$(call TOLERATIONS_TEMPLATE,$(SAFETY_TOLERATION))',)
 
-install-llm-service-%: namespace secrets
+install-llm-service-%: namespace
 	@$(eval HELM_ARGS := $(call helm_llm_service_args))
 
 	@echo "Deploying Helm chart $(LLM_SERVICE_CHART_PATH) as release $(LLM_SERVICE_RELEASE_NAME) in namespace $(NAMESPACE)..."; \
@@ -144,6 +131,8 @@ helm_llama_stack_args = \
     --set pgvector.secret.user=$(POSTGRES_USER) \
     --set pgvector.secret.password=$(POSTGRES_PASSWORD) \
     --set pgvector.secret.dbname=$(POSTGRES_DBNAME) \
+    --set minio.secret.user=$(MINIO_USER) \
+    --set minio.secret.password=$(MINIO_PASSWORD) \
     $(if $(LLM),--set-json llama-stack.models.$(LLM).enabled='true',) \
     $(if $(SAFETY),--set-json llama-stack.models.$(SAFETY).enabled='true',) \
     $(if $(LLM_URL),--set-json llama-stack.models.$(LLM).url='"$(LLM_URL)"',) \
@@ -158,7 +147,7 @@ create-minio-bucket:
 	oc exec -n $(NAMESPACE) minio-0 -- bash -c "mc alias set local http://localhost:9000 $(MINIO_USER) $(MINIO_PASSWORD) && mc mb local/$(BUCKET_NAME)" ||:
 
 .PHONY: install-rag
-install-rag: namespace secrets install-mcp-servers
+install-rag: namespace install-mcp-servers
 	@$(eval HELM_ARGS := $(call helm_llama_stack_args))
 
 	@echo "Deploying Helm chart $(CHART_PATH) as release $(RELEASE_NAME) in namespace $(NAMESPACE)..."
@@ -222,9 +211,6 @@ uninstall-helm-release:
 
 .PHONY: remove-secrets
 remove-secrets:
-
-	@echo "Removing minio secret"
-	oc delete secret -n $(NAMESPACE) minio || echo "Secret not found or already removed."
 
 	@echo "Removing pipeline secret"
 	oc delete secret -n $(NAMESPACE) rag-pipeline-secrets || echo "Secret not found or already removed."

--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -73,16 +73,6 @@ secrets:
 			oc create secret -n $(NAMESPACE) generic huggingface-secret --from-literal=HF_TOKEN="$$HF_TOKEN" --dry-run=client -o yaml | oc apply -f -'; \
 	}
 
-	@oc get secret -n $(NAMESPACE) pgvector 2>/dev/null || { \
-		echo "Creating pgvector secret"; \
-		oc create secret -n $(NAMESPACE) generic pgvector \
-			--from-literal=username="$(POSTGRES_USER)" \
-			--from-literal=password="$(POSTGRES_PASSWORD)" \
-			--from-literal=host=pgvector \
-			--from-literal=port=5432 \
-			--from-literal=dbname="$(POSTGRES_DBNAME)"; \
-	}
-
 	@oc get secret -n $(NAMESPACE) minio 2>/dev/null || { \
 		echo "Creating minio secret"; \
 		oc create secret -n $(NAMESPACE) generic minio \
@@ -94,7 +84,6 @@ secrets:
 
 	@echo "Annotating secrets..."
 	oc annotate secret huggingface-secret -n $(NAMESPACE) meta.helm.sh/release-name=$(RELEASE_NAME) meta.helm.sh/release-namespace=$(NAMESPACE) --overwrite
-	oc annotate secret pgvector -n $(NAMESPACE) meta.helm.sh/release-name=rag meta.helm.sh/release-namespace=$(NAMESPACE)
 	oc annotate secret minio -n $(NAMESPACE) meta.helm.sh/release-name=rag meta.helm.sh/release-namespace=$(NAMESPACE)
 
 .PHONY: pg-vector
@@ -158,6 +147,9 @@ install-llm-service-%: namespace secrets
 install-llm-service: install-llm-service-gpu
 
 helm_llama_stack_args = \
+    --set pgvector.secret.user=$(POSTGRES_USER) \
+    --set pgvector.secret.password=$(POSTGRES_PASSWORD) \
+    --set pgvector.secret.dbname=$(POSTGRES_DBNAME) \
     $(if $(LLM),--set-json llama-stack.models.$(LLM).enabled='true',) \
     $(if $(SAFETY),--set-json llama-stack.models.$(SAFETY).enabled='true',) \
     $(if $(LLM_URL),--set-json llama-stack.models.$(LLM).url='"$(LLM_URL)"',) \
@@ -239,9 +231,6 @@ remove-secrets:
 
 	@echo "Removing Hugging Face secret..."
 	oc delete secret -n $(NAMESPACE) huggingface-secret || echo "Secret not found or already removed."
-
-	@echo "Removing pgvector secret"
-	oc delete secret -n $(NAMESPACE) pgvector || echo "Secret not found or already removed."
 
 	@echo "Removing minio secret"
 	oc delete secret -n $(NAMESPACE) minio || echo "Secret not found or already removed."

--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -67,14 +67,6 @@ namespace:
 	oc create namespace $(NAMESPACE) && oc label namespace $(NAMESPACE) modelmesh-enabled=false ||:
 	oc project $(NAMESPACE) ||:
 
-.PHONY: pg-vector
-pg-vector:
-
-	@echo "Bootstrapping pgvector database"
-	oc rollout -n $(NAMESPACE) status sts/pgvector
-	oc exec -itn $(NAMESPACE) sts/pgvector -- psql -U postgres -c "CREATE DATABASE $(POSTGRES_DBNAME);" ||:
-	oc exec -itn $(NAMESPACE) sts/pgvector -- psql -U postgres -d $(POSTGRES_DBNAME) -c "CREATE EXTENSION VECTOR;" ||:
-
 .PHONY: install-mcp-servers
 install-mcp-servers: namespace
 
@@ -153,7 +145,6 @@ install-rag: namespace install-mcp-servers
 	@echo "Deploying Helm chart $(CHART_PATH) as release $(RELEASE_NAME) in namespace $(NAMESPACE)..."
 	helm upgrade --install $(RELEASE_NAME) $(CHART_PATH) -n $(NAMESPACE) $(HELM_ARGS) $(EXTRA_HELM_ARGS)
 
-	@$(MAKE) pg-vector
 	@$(MAKE) create-minio-bucket
 
 	@$(MAKE) status

--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -15,6 +15,7 @@ MINIO_USER ?= minio_rag_user
 MINIO_PASSWORD ?= minio_rag_password
 RELEASE_NAME ?= rag
 CHART_PATH ?= rag-ui
+HF_TOKEN ?= $(shell bash -c 'read -r -p "Enter Hugging Face Token: " HF_TOKEN; echo $$HF_TOKEN')
 LLM_SERVICE_CHART_PATH ?= llm-service
 LLM_SERVICE_RELEASE_NAME ?= llm-service
 MCP_SERVERS_CHART_PATH ?= mcp-servers
@@ -67,12 +68,6 @@ namespace:
 	oc project $(NAMESPACE) ||:
 
 secrets:
-	@oc get secret -n $(NAMESPACE) huggingface-secret 2>/dev/null || { \
-		echo "Creating Hugging Face secret..."; \
-		bash -c 'read -r -p "Enter Hugging Face Token: " HF_TOKEN; echo $$HF_TOKEN; \
-			oc create secret -n $(NAMESPACE) generic huggingface-secret --from-literal=HF_TOKEN="$$HF_TOKEN" --dry-run=client -o yaml | oc apply -f -'; \
-	}
-
 	@oc get secret -n $(NAMESPACE) minio 2>/dev/null || { \
 		echo "Creating minio secret"; \
 		oc create secret -n $(NAMESPACE) generic minio \
@@ -83,7 +78,6 @@ secrets:
 	}
 
 	@echo "Annotating secrets..."
-	oc annotate secret huggingface-secret -n $(NAMESPACE) meta.helm.sh/release-name=$(RELEASE_NAME) meta.helm.sh/release-namespace=$(NAMESPACE) --overwrite
 	oc annotate secret minio -n $(NAMESPACE) meta.helm.sh/release-name=rag meta.helm.sh/release-namespace=$(NAMESPACE)
 
 .PHONY: pg-vector
@@ -137,9 +131,9 @@ helm_llm_service_args = \
 install-llm-service-%: namespace secrets
 	@$(eval HELM_ARGS := $(call helm_llm_service_args))
 
-	@echo "Deploying Helm chart $(LLM_SERVICE_CHART_PATH) as release $(LLM_SERVICE_RELEASE_NAME) in namespace $(NAMESPACE)..."
+	@echo "Deploying Helm chart $(LLM_SERVICE_CHART_PATH) as release $(LLM_SERVICE_RELEASE_NAME) in namespace $(NAMESPACE)..."; \
 	helm upgrade --install $(LLM_SERVICE_RELEASE_NAME) $(LLM_SERVICE_CHART_PATH) -n $(NAMESPACE) --values $(LLM_SERVICE_CHART_PATH)/values-$*.yaml \
-	$(HELM_ARGS) $(EXTRA_HELM_ARGS)
+		--set hf_token=$(HF_TOKEN) $(HELM_ARGS) $(EXTRA_HELM_ARGS)
 	@echo "Waiting for model services to deploy. It will take around 10-15 minutes depending on the size of the model..."
 	oc wait -n $(NAMESPACE) --for=condition=Ready --timeout=60m inferenceservice --all ||:
 
@@ -228,9 +222,6 @@ uninstall-helm-release:
 
 .PHONY: remove-secrets
 remove-secrets:
-
-	@echo "Removing Hugging Face secret..."
-	oc delete secret -n $(NAMESPACE) huggingface-secret || echo "Secret not found or already removed."
 
 	@echo "Removing minio secret"
 	oc delete secret -n $(NAMESPACE) minio || echo "Secret not found or already removed."

--- a/deploy/helm/llm-service/templates/secret.yaml
+++ b/deploy/helm/llm-service/templates/secret.yaml
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: huggingface-secret
+data:
+  HF_TOKEN: {{ .Values.hf_token | b64enc | quote }}
+type: Opaque

--- a/deploy/helm/llm-service/values.yaml
+++ b/deploy/helm/llm-service/values.yaml
@@ -22,3 +22,4 @@ servingRuntime:
   - emptyDir:
       sizeLimit: 5Gi
     name: vllm-home
+hf_token: ""

--- a/deploy/helm/rag-ui/charts/llama-stack/values.yaml
+++ b/deploy/helm/rag-ui/charts/llama-stack/values.yaml
@@ -54,7 +54,7 @@ env:
   - name: POSTGRES_USER
     valueFrom:
       secretKeyRef:
-        key: username
+        key: user
         name: pgvector
   - name: POSTGRES_PASSWORD
     valueFrom:

--- a/deploy/helm/rag-ui/charts/minio/templates/secret.yaml
+++ b/deploy/helm/rag-ui/charts/minio/templates/secret.yaml
@@ -1,0 +1,12 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: minio
+  labels:
+    {{- include "pgvector.labels" . | nindent 4 }}
+data:
+  user: {{ .Values.secret.user | b64enc | quote }}
+  password: {{ .Values.secret.password | b64enc | quote }}
+  host: {{ .Values.secret.host | b64enc | quote }}
+  port: {{ .Values.secret.port | b64enc | quote }}
+type: Opaque

--- a/deploy/helm/rag-ui/charts/minio/values.yaml
+++ b/deploy/helm/rag-ui/charts/minio/values.yaml
@@ -38,7 +38,7 @@ env:
   - name: MINIO_ROOT_USER
     valueFrom:
       secretKeyRef:
-        key: username
+        key: user
         name: minio
   - name: MINIO_ROOT_PASSWORD
     valueFrom:
@@ -66,3 +66,9 @@ volumeMounts:
 
 nodeSelector: {}
 affinity: {}
+
+secret:
+  user: minio_rag_user
+  password: minio_rag_password
+  host: minio
+  port: "9000"

--- a/deploy/helm/rag-ui/charts/pgvector/templates/configmap.yaml
+++ b/deploy/helm/rag-ui/charts/pgvector/templates/configmap.yaml
@@ -1,0 +1,12 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: pgvector-initsql
+  labels:
+    {{- include "pgvector.labels" . | nindent 4 }}
+data:
+  init-db.sh: |
+    #!/bin/bash
+    set -e
+    psql -U postgres -c "CREATE DATABASE ${POSTGRES_DBNAME};"
+    psql -U postgres -d ${POSTGRES_DBNAME} -c "CREATE EXTENSION VECTOR;"

--- a/deploy/helm/rag-ui/charts/pgvector/templates/secret.yaml
+++ b/deploy/helm/rag-ui/charts/pgvector/templates/secret.yaml
@@ -1,0 +1,13 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: pgvector
+  labels:
+    {{- include "pgvector.labels" . | nindent 4 }}
+data:
+  user: {{ .Values.secret.user | b64enc | quote }}
+  password: {{ .Values.secret.password | b64enc | quote }}
+  host: {{ .Values.secret.host | b64enc | quote }}
+  port: {{ .Values.secret.port | b64enc | quote }}
+  dbname: {{ .Values.secret.dbname | b64enc | quote }}
+type: Opaque

--- a/deploy/helm/rag-ui/charts/pgvector/templates/statefulset.yaml
+++ b/deploy/helm/rag-ui/charts/pgvector/templates/statefulset.yaml
@@ -80,3 +80,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: initdb-volume
+          configMap:
+            name: pgvector-initsql

--- a/deploy/helm/rag-ui/charts/pgvector/values.yaml
+++ b/deploy/helm/rag-ui/charts/pgvector/values.yaml
@@ -32,7 +32,7 @@ env:
   - name: POSTGRES_USER
     valueFrom:
       secretKeyRef:
-        key: username
+        key: user
         name: pgvector
   - name: POSTGRES_PASSWORD
     valueFrom:
@@ -77,3 +77,10 @@ volumeMounts:
 
 nodeSelector: {}
 affinity: {}
+
+secret:
+  user: postgres
+  password: rag_password
+  dbname: rag_blueprint
+  host: pgvector
+  port: "5432"

--- a/deploy/helm/rag-ui/charts/pgvector/values.yaml
+++ b/deploy/helm/rag-ui/charts/pgvector/values.yaml
@@ -72,6 +72,8 @@ volumeClaimTemplates:
           storage: 5Gi
 
 volumeMounts:
+  - mountPath: /docker-entrypoint-initdb.d
+    name: initdb-volume
   - mountPath: /var/lib/postgresql
     name: pg-data
 


### PR DESCRIPTION
For automated deployment scenarios, it is preferable for all Kubernetes resources to be managed as part of a Helm chart rather than imperatively in the Makefile.

This PR moves the pgvector secret into the pgvector subchart and populates it with the existing default values. The user is able to set the values via Helm overrides, or by setting environment variables when deploying via the Makefile (as is already currently possible).