### PR TITLE
Make it possible to enable/disable secret creation for HF token

### DIFF
--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -116,7 +116,7 @@ install-llm-service-%: namespace
 
 	@echo "Deploying Helm chart $(LLM_SERVICE_CHART_PATH) as release $(LLM_SERVICE_RELEASE_NAME) in namespace $(NAMESPACE)..."; \
 	helm upgrade --install $(LLM_SERVICE_RELEASE_NAME) $(LLM_SERVICE_CHART_PATH) -n $(NAMESPACE) --values $(LLM_SERVICE_CHART_PATH)/values-$*.yaml \
-		--set hf_token=$(HF_TOKEN) $(HELM_ARGS) $(EXTRA_HELM_ARGS)
+		--set secret.hf_token=$(HF_TOKEN) $(HELM_ARGS) $(EXTRA_HELM_ARGS)
 	@echo "Waiting for model services to deploy. It will take around 10-15 minutes depending on the size of the model..."
 	oc wait -n $(NAMESPACE) --for=condition=Ready --timeout=60m inferenceservice --all ||:
 

--- a/deploy/helm/llm-service/templates/secret.yaml
+++ b/deploy/helm/llm-service/templates/secret.yaml
@@ -1,7 +1,9 @@
+{{- if .Values.secret.enabled }}
 kind: Secret
 apiVersion: v1
 metadata:
   name: huggingface-secret
 data:
-  HF_TOKEN: {{ .Values.hf_token | b64enc | quote }}
+  HF_TOKEN: {{ .Values.secret.hf_token | b64enc | quote }}
 type: Opaque
+{{- end }}

--- a/deploy/helm/llm-service/values.yaml
+++ b/deploy/helm/llm-service/values.yaml
@@ -22,4 +22,6 @@ servingRuntime:
   - emptyDir:
       sizeLimit: 5Gi
     name: vllm-home
-hf_token: ""
+secret:
+  enabled: true
+  hf_token: ""


### PR DESCRIPTION
In the case where the secret for HF token should be created and managed outside of Helm, make it possible to disable the creation of the Kubernetes secret resource.