### PR TITLE
Support multiple secrets as env vars

### DIFF
--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -133,7 +133,7 @@ helm_llama_stack_args = \
     $(if $(SAFETY_URL),--set-json llama-stack.models.$(SAFETY).url='"$(SAFETY_URL)"',) \
     $(if $(LLM_API_TOKEN),--set-json llama-stack.models.$(LLM).apiToken='"$(LLM_API_TOKEN)"',) \
     $(if $(SAFETY_API_TOKEN),--set-json llama-stack.models.$(SAFETY).apiToken='"$(SAFETY_API_TOKEN)"',) \
-    $(if $(TAVILY_SEARCH_API_TOKEN),--set llama-stack.secrets.tavily-search.value=$(TAVILY_SEARCH_API_TOKEN),)
+    $(if $(LLAMA_STACK_ENV),--set-json llama-stack.secrets='$(LLAMA_STACK_ENV)',)
 
 .PHONY: create-minio-bucket
 create-minio-bucket:

--- a/deploy/helm/rag-ui/charts/llama-stack/templates/deployment.yaml
+++ b/deploy/helm/rag-ui/charts/llama-stack/templates/deployment.yaml
@@ -43,15 +43,9 @@ spec:
             {{- toYaml .Values.args | nindent 12 }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
-            {{- range $key, $secret := .Values.secrets }}
-            {{- if not (empty $secret.value) }}
-            - name: {{ $secret.env }}
-              valueFrom:
-                secretKeyRef:
-                  key: {{ $secret.env }}
-                  name: {{ $key }}
-            {{- end }}
-            {{- end }}
+          envFrom:
+          - secretRef:
+              name: {{ .Chart.Name }}-env
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/deploy/helm/rag-ui/charts/llama-stack/templates/secret.yaml
+++ b/deploy/helm/rag-ui/charts/llama-stack/templates/secret.yaml
@@ -1,12 +1,10 @@
-{{- range $key, $secret := .Values.secrets }}
-{{- if not (empty $secret.value) }}
 ---
 kind: Secret
 apiVersion: v1
 metadata:
-  name: {{ $key }}
-data:
-  {{ $secret.env }}: {{ $secret.value | b64enc | quote }}
+  name: {{ .Chart.Name }}-env
 type: Opaque
-{{- end }}
-{{- end }}
+data:
+  {{- range $key, $value:= .Values.secrets }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}

--- a/deploy/helm/rag-ui/charts/llama-stack/values.yaml
+++ b/deploy/helm/rag-ui/charts/llama-stack/values.yaml
@@ -131,9 +131,7 @@ tolerations: []
 affinity: {}
 
 secrets:
-  tavily-search:
-    env: TAVILY_SEARCH_API_KEY
-    value:
+  TAVILY_SEARCH_API_KEY: fake
 
 models:
   llama-3-2-3b-instruct:


### PR DESCRIPTION
Secrets can be added during installation as follows:

make install ... LLAMA_STACK_ENV='{"TAVILY_SEARCH_API_KEY": "XXX"}'